### PR TITLE
Optimize the loop in the vector helper function for vle*.v/vse*.v instructions.

### DIFF
--- a/target/riscv/vector_helper.c
+++ b/target/riscv/vector_helper.c
@@ -277,8 +277,20 @@ vext_ldst_us(void *vd, target_ulong base, CPURISCVState *env, uint32_t desc,
 
     VSTART_CHECK_EARLY_EXIT(env);
 
+    uint32_t mod = evl % 8;
+
     /* load bytes from guest memory */
-    for (i = env->vstart; i < evl; env->vstart = ++i) {
+    for (i = env->vstart; i < (evl - mod); env->vstart = i) {
+        k = 0;
+        while (k < nf) {
+            target_ulong addr = base + ((i * nf + k) << log2_esz);
+            lde_d(env, adjust_addr(env, addr), i + k * max_elems, vd, ra);
+            k++;
+        }
+    i += 8;
+    }
+    env->vstart = i;
+    for (; i < evl; env->vstart = ++i) {
         k = 0;
         while (k < nf) {
             target_ulong addr = base + ((i * nf + k) << log2_esz);


### PR DESCRIPTION
This pull request optimizes the loop used to simulate the vle8.v, vle16.v... vse8.v, vse16.v and a few others, but using 8-byte load/store operations and consecutively reducing the loop iterations by 8.